### PR TITLE
Switch Travis CI build order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 language: go
 
 go:
-  - tip
   - 1.7.3
+  - tip
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Travis appears to run builds sequentially (at least on the plan I'm on),
in the order they're specified in the file. Switch them so that the
stable build completes first, which means I'll know if a pull request
has passed much faster.
