### PR TITLE
Add integration test environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.8-alpine
+MAINTAINER Matt Bostock <matt@mattbostock.com>
+
+EXPOSE 9080
+
+WORKDIR /go/src/github.com/mattbostock/athens
+COPY . /go/src/github.com/mattbostock/athens
+
+RUN apk add --update make && \
+  make && \
+  apk del make && \
+  cd && \
+  rm -rf /go/src
+
+ENTRYPOINT ["/go/bin/athens"]

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  athens:
+    build: ../
+    ports:
+      - 9080:9080
+  prometheus:
+    build: prometheus/
+    links:
+      - athens

--- a/integration_tests/prometheus/Dockerfile
+++ b/integration_tests/prometheus/Dockerfile
@@ -1,0 +1,5 @@
+FROM prom/prometheus:v1.6.0
+
+COPY prometheus.yml /etc/prometheus/prometheus.yml
+
+CMD [ "-config.file=/etc/prometheus/prometheus.yml", "-storage.local.engine=none" ]

--- a/integration_tests/prometheus/prometheus.yml
+++ b/integration_tests/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 1s
+  evaluation_interval: 1s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090
+
+remote_write:
+  - url: http://athens:9080/receive


### PR DESCRIPTION
Add a Dockerfile to build an Athens Docker image and a Docker Compose
file that can spin up a Prometheus 1.6 instance that feeds sample
metrics into Athens.

I haven't added any integration tests at this point, but the change here
creates the environment that the integration tests can run against.

Implements part of #36.