### PR TITLE
Change name to AthensDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This project is an early alpha, written for education purposes. Please don't
 consider putting it into Production.
 
-# Athens
+# AthensDB
 
-[![Build Status](https://travis-ci.com/mattbostock/athens.svg?token=EhqoSPmXWFAXy2qpEaqr&branch=master)](https://travis-ci.com/mattbostock/athens)
+[![Build Status](https://travis-ci.com/mattbostock/athensdb.svg?token=EhqoSPmXWFAXy2qpEaqr&branch=master)](https://travis-ci.com/mattbostock/athensdb)
 
-Athens is a distributed, fault-tolerant time series database that supports PromQL.
+AthensDB is a distributed, fault-tolerant time series database that supports PromQL.
 
 It is intended to provide durable long-term storage for multi-dimensional time
 series data.
@@ -21,11 +21,11 @@ query language.
 foremost for reliability, clustering and durable storage are explicit project
 non-goals.
 
-Athens is intended for use as a secondary, durable, data store for time series
+AthensDB is intended for use as a secondary, durable, data store for time series
 data. It supports PromQL and the Prometheus query API, but does not depend on
 Prometheus.
 
-Data stored in Athens can be visualised using [Grafana][].
+Data stored in AthensDB can be visualised using [Grafana][].
 
 [Prometheus]: https://prometheus.io/
 [Grafana]: http://grafana.org/

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
-	"github.com/mattbostock/athens/remote"
+	"github.com/mattbostock/athensdb/remote"
 	"github.com/prometheus/common/model"
 )
 

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
-	v1API "github.com/mattbostock/athens/api/v1"
-	"github.com/mattbostock/athens/remote"
+	v1API "github.com/mattbostock/athensdb/api/v1"
+	"github.com/mattbostock/athensdb/remote"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/pkg/labels"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -302,5 +302,5 @@
 			"revisionTime": "2017-04-10T11:03:47Z"
 		}
 	],
-	"rootPath": "github.com/mattbostock/athens"
+	"rootPath": "github.com/mattbostock/athensdb"
 }


### PR DESCRIPTION
AthensDB makes it more obvious that it's a database, plus the domain
name, Twitter handle and GitHub organisation are available:

    athensdb.io
    @athensdb
    github.com/athensdb