### PR TITLE
Ignore data directory created by tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+data/
 site/


### PR DESCRIPTION
Running `make test` creates a data directory. Add it to `.gitignore` so
I don't accidentally commit it.