### PR TITLE
Fix remaining references to 'athens'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER Matt Bostock <matt@mattbostock.com>
 
 EXPOSE 9080
 
-WORKDIR /go/src/github.com/mattbostock/athens
-COPY . /go/src/github.com/mattbostock/athens
+WORKDIR /go/src/github.com/mattbostock/athensdb
+COPY . /go/src/github.com/mattbostock/athensdb
 
 RUN apk add --update make && \
   make && \
@@ -12,4 +12,4 @@ RUN apk add --update make && \
   cd && \
   rm -rf /go/src
 
-ENTRYPOINT ["/go/bin/athens"]
+ENTRYPOINT ["/go/bin/athensdb"]

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3'
 services:
-  athens:
+  athensdb:
     build: ../
     ports:
       - 9080:9080
   prometheus:
     build: prometheus/
     links:
-      - athens
+      - athensdb

--- a/integration_tests/prometheus/prometheus.yml
+++ b/integration_tests/prometheus/prometheus.yml
@@ -9,4 +9,4 @@ scrape_configs:
           - localhost:9090
 
 remote_write:
-  - url: http://athens:9080/receive
+  - url: http://athensdb:9080/receive


### PR DESCRIPTION
Athens was renamed to AthensDB in ca144dae011. Update some stray
references to the old name.