### PR TITLE
Decouple testing docs from app tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ matrix:
   allow_failures:
     - tip
   fast_finish: true
+
+script: make test && make testdocs

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,11 @@ build:
 savedeps:
 	@govendor add +external
 
+test:
+	@go test $(shell go list ./... | grep -v /vendor/)
+
 servedocs:
 	@docker run --rm -it -p 8000:8000 -v `pwd`:/docs squidfunk/mkdocs-material:$(MKDOCS_MATERIAL_VERSION)
 
-test:
-	@go test $(shell go list ./... | grep -v /vendor/)
+testdocs:
 	@docker run --rm -it -v `pwd`:/docs squidfunk/mkdocs-material:$(MKDOCS_MATERIAL_VERSION) build -s


### PR DESCRIPTION
I wanted to ensure that the documentation can always be rendered, so I
included it under the `test` Makefile target.

Because the `build` target depends on the `test` target,
the integration test environment added in 6eb62917bb was failing to
build due to the Docker dependency used to build the docs.

Rather than install Docker in the integration test environment, decouple
testing the documentation from the code itself, and ensure that Travis
tests both when a pull request is raised.