### PR TITLE
Switch to unframed snappy under Prometheus 1.7.x

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -75,13 +75,9 @@ func TestRemoteWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	buf := bytes.Buffer{}
-	if _, err := snappy.NewWriter(&buf).Write(data); err != nil {
-		t.Fatal(err)
-	}
-
+	compressed := snappy.Encode(nil, data)
 	u := fmt.Sprintf("%s%s", baseURL, writeRoute)
-	httpResp, err := http.Post(u, "snappy", &buf)
+	httpResp, err := http.Post(u, "snappy", bytes.NewBuffer(compressed))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration_tests/prometheus/Dockerfile
+++ b/integration_tests/prometheus/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/prometheus:v1.6.0
+FROM prom/prometheus:v1.7.1
 
 COPY prometheus.yml /etc/prometheus/prometheus.yml
 

--- a/main.go
+++ b/main.go
@@ -64,7 +64,13 @@ func main() {
 	api.Register(router.WithPrefix(apiRoute))
 
 	router.Post("/receive", func(w http.ResponseWriter, r *http.Request) {
-		reqBuf, err := ioutil.ReadAll(snappy.NewReader(r.Body))
+		compressed, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		reqBuf, err := snappy.Decode(nil, compressed)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
Prometheus switched to use unframed Snappy encoding as of version 1.7.0.

Upgrade Prometheus in the integration test environment to 1.7.1 and
update the remote read API endpoint to accept unframed Snappy-encoded
data from Prometheus, and update the acceptance tests to match.

See:
https://github.com/prometheus/prometheus/issues/2692
https://github.com/prometheus/prometheus/tree/v1.7.0