### PR TITLE
Fix Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all: test testdocs build
-.PHONY: build savedeps servedocs test testdocs
+.PHONY: all build savedeps servedocs test testdocs
 
 MKDOCS_MATERIAL_VERSION=1.5.4
 


### PR DESCRIPTION
85933ad added the `testdocs` target but omitted to include it in the
`all` target or in `.PHONY`.