### PR TITLE
Enable race detection during tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine
+FROM golang:1.8
 MAINTAINER Matt Bostock <matt@mattbostock.com>
 
 EXPOSE 9080
@@ -6,9 +6,10 @@ EXPOSE 9080
 WORKDIR /go/src/github.com/mattbostock/athensdb
 COPY . /go/src/github.com/mattbostock/athensdb
 
-RUN apk add --no-cache git make && \
+RUN apt-get update && \
+  apt-get install -y git make && \
   make && \
-  apk del make && \
+  apt-get purge -y git make && \
   cd && \
   rm -rf /go/src
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ savedeps:
 	@govendor add +external
 
 test:
-	@go test $(shell go list ./... | grep -v /vendor/)
+	@go test -race $(shell go list ./... | grep -v /vendor/)
 
 servedocs:
 	@docker run --rm -it -p 8000:8000 -v `pwd`:/docs squidfunk/mkdocs-material:$(MKDOCS_MATERIAL_VERSION)

--- a/integration_tests/Dockerfile
+++ b/integration_tests/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.8-alpine
+FROM golang:1.8
 MAINTAINER Matt Bostock <matt@mattbostock.com>
 
 WORKDIR /go/src/github.com/mattbostock/athensdb
 COPY . /go/src/github.com/mattbostock/athensdb
 
-RUN go test -c -o /bin/athensdb.test -tags integration ./integration_tests && \
+RUN go test -c -o /bin/athensdb.test -race -tags integration ./integration_tests && \
   cd /bin && \
   rm -rf /go/src
 


### PR DESCRIPTION
Enable the Go race detector to help surface race conditions when
running the tests.

The race detector currently depends on libc, so does not work with
Alpine Linux (which uses musl):

https://github.com/golang/go/issues/9918
https://github.com/golang/go/issues/14481

Instead, use the default Go Docker image, which uses the libc-based
Debian Jessie and update the Dockerfiles accordingly.

* * *

Closes #58.