### PR TITLE
Integration tests: fix (*testing.T).Fatal race

### DIFF
--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -30,18 +30,21 @@ func TestPrometheusMetricsCanBeQueried(t *testing.T) {
 			query := `prometheus_build_info`
 			result, err := helpers.QueryAPI(addr, query, time.Now())
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 
 			expected := model.SampleValue(1)
 
 			if len(result.(model.Vector)) == 0 {
-				t.Fatalf("Got 0 results")
+				t.Error("Got 0 results")
+				return
 			}
 
 			got := result.(model.Vector)[0].Value
 			if got != expected {
-				t.Fatalf("Expected %s, got %s", expected, got)
+				t.Error("Expected %s, got %s", expected, got)
+				return
 			}
 		}(a)
 	}


### PR DESCRIPTION
From https://golang.org/pkg/testing/#T:

> A test ends when its Test function returns or calls any of the methods
> FailNow, Fatal, Fatalf, SkipNow, Skip, or Skipf. Those methods, as
> well as the Parallel method, must be called only from the goroutine
> running the Test function.
>
> The other reporting methods, such as the variations of Log and Error,
> may be called simultaneously from multiple goroutines.

Use `(*T).Error` instead, which should be safe to call from multiple
goroutines.

See also:
https://github.com/golang/go/issues/15976

The race was exhibited as:

    integration-tests_1         | WARNING: DATA RACE
    integration-tests_1         | Write at 0x00c420064934 by goroutine 8:
    integration-tests_1         |   testing.(*common).FailNow()
    integration-tests_1         |       /usr/local/go/src/testing/testing.go:485 +0x4a
    integration-tests_1         |   testing.(*common).Fatal()
    integration-tests_1         |       /usr/local/go/src/testing/testing.go:524 +0x7c
    integration-tests_1         |   github.com/mattbostock/athensdb/integration_tests.TestPrometheusMetricsCanBeQueried.func1()
    integration-tests_1         |       /go/src/github.com/mattbostock/athensdb/integration_tests/integration_test.go:33 +0x17c
    integration-tests_1         |
    integration-tests_1         | Previous write at 0x00c420064934 by goroutine 10:
    integration-tests_1         |   testing.(*common).FailNow()
    integration-tests_1         |       /usr/local/go/src/testing/testing.go:485 +0x4a
    integration-tests_1         |   testing.(*common).Fatal()
    integration-tests_1         |       /usr/local/go/src/testing/testing.go:524 +0x7c
    integration-tests_1         |   github.com/mattbostock/athensdb/integration_tests.TestPrometheusMetricsCanBeQueried.func1()
    integration-tests_1         |       /go/src/github.com/mattbostock/athensdb/integration_tests/integration_test.go:33 +0x17c
    integration-tests_1         |
    integration-tests_1         | Goroutine 8 (running) created at:
    integration-tests_1         |   github.com/mattbostock/athensdb/integration_tests.TestPrometheusMetricsCanBeQueried()
    integration-tests_1         |       /go/src/github.com/mattbostock/athensdb/integration_tests/integration_test.go:46 +0x12f
    integration-tests_1         |   testing.tRunner()
    integration-tests_1         |       /usr/local/go/src/testing/testing.go:657 +0x107
    integration-tests_1         |
    integration-tests_1         | Goroutine 10 (finished) created at:
    integration-tests_1         |   github.com/mattbostock/athensdb/integration_tests.TestPrometheusMetricsCanBeQueried()
    integration-tests_1         |       /go/src/github.com/mattbostock/athensdb/integration_tests/integration_test.go:46 +0x12f
    integration-tests_1         |   testing.tRunner()
    integration-tests_1         |       /usr/local/go/src/testing/testing.go:657 +0x107
    integration-tests_1         | ==================