### PR TITLE
Move cluster logic to its own package

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1,0 +1,93 @@
+package cluster
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"strconv"
+
+	"github.com/hashicorp/memberlist"
+)
+
+var c = struct {
+	d  *delegate
+	ml *memberlist.Memberlist
+}{
+	d: &delegate{},
+}
+
+type Config struct {
+	AdvertiseAddr string
+	BindAddr      string
+	Peers         []string
+}
+
+func Join(config *Config) error {
+	// FIXME(mbostock): Consider using a non-local config for memberlist
+	memberConf := memberlist.DefaultLocalConfig()
+	advHost, advPort, _ := net.SplitHostPort(config.BindAddr)
+	bindPort, _ := strconv.Atoi(advPort)
+	memberConf.BindAddr = advHost
+	memberConf.BindPort = bindPort
+	memberConf.LogOutput = ioutil.Discard
+
+	var err error
+	if c.ml, err = memberlist.Create(memberConf); err != nil {
+		return fmt.Errorf("Failed to configure cluster settings: %s", err)
+	}
+	c.ml.Join(config.Peers)
+	return nil
+}
+
+type Node struct {
+	mln *memberlist.Node
+}
+
+func (n *Node) Name() string {
+	return n.mln.Name
+}
+func (n *Node) Addr() string {
+	return fmt.Sprintf("%s:%d", n.mln.Addr.String(), n.mln.Port)
+}
+func (n *Node) String() string {
+	return n.Name()
+}
+
+func LocalNode() *Node {
+	if c.ml == nil {
+		panic("Not yet joined a cluster")
+	}
+	return &Node{c.ml.LocalNode()}
+}
+
+func Nodes() (nodes []*Node) {
+	if c.ml == nil {
+		panic("Not yet joined a cluster")
+	}
+	for _, n := range c.ml.Members() {
+		nodes = append(nodes, &Node{n})
+	}
+	return
+}
+
+type delegate struct{}
+
+func (d *delegate) NodeMeta(limit int) []byte {
+	panic("not implemented")
+}
+
+func (d *delegate) NotifyMsg([]byte) {
+	panic("not implemented")
+}
+
+func (d *delegate) GetBroadcasts(overhead int, limit int) [][]byte {
+	panic("not implemented")
+}
+
+func (d *delegate) LocalState(join bool) []byte {
+	panic("not implemented")
+}
+
+func (d *delegate) MergeRemoteState(buf []byte, join bool) {
+	panic("not implemented")
+}


### PR DESCRIPTION
In preparation for #62.

* * *

Create a new internal package, `cluster` which abstracts (adapts)
Hashicorp's memberlist library.

The `cluster` package acts as a singleton, so I'm storing its state
(`c`) as a package-level variable.

I considered avoiding the package-level variable in favour of returning
a struct from `Join()`, however I wanted to be able to use:

    err := cluster.Join(config)
    fmt.Println(cluster.Nodes())

...instead of something like:

    peer, err := cluster.Join(config)
    fmt.Println(peer.ClusterNodes())

...which seems awkward.

I can perform dependency injection when testing within the same package,
but I may later find I need to remove the package-level variable to make
testing easier.

As a side-effect of moving all the cluster code into the `Join()`
function, the HTTP server now starts after the cluster is initialised,
which I had previously tried to avoid so that nodes wouldn't try to
connect to the HTTP API of nodes whose HTTP server hadn't yet started.
I'll come back to that later when I rework the data sample forwarding
logic.

The code here is heavily based on:
https://github.com/oklog/oklog/blob/fca58330910eb7fe6267788eddf879b1d6811176/pkg/cluster/peer.go

...which in turn is based on:
https://github.com/asim/memberlist/blob/92a93e41725fd47cdde304d91183fca1754c2cf9/memberlist.go