### PR TITLE
Lazy-load Makefile variables that shell out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: test build
 .PHONY: all build clean integration savedeps servedocs test testdeps testdocs
 
-MKDOCS_MATERIAL_VERSION=1.5.4
+MKDOCS_MATERIAL_VERSION = 1.5.4
 VERSION = $(shell git describe --always | tr -d '\n'; test -z "`git status --porcelain`" || echo '-dirty')
 UNUSED_LIBS = $(shell govendor list +unused)
 


### PR DESCRIPTION
Lazy-load the Makefile variables that shell out to prevent them from
being expanded unless they're needed.

Prevents the integration tests (running on Debian under Docker) from
complaining that `govendor` is not installed even though it's not used:

    make: govendor: Command not found

Make targets that do not use these variables should also run very
marginally faster.