### PR TITLE
Upgrade Go runtime to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: go
 
 go:
-  - 1.8.x
+  - 1.9.x
   - tip
 
 services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.8 as build
+FROM golang:1.9 as build
 WORKDIR /go/src/github.com/mattbostock/athensdb
 RUN apt-get update
 RUN apt-get upgrade -y ca-certificates

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ savedeps:
 	@govendor add +external
 
 test:
-	@go test -race $(shell go list ./... | grep -v /vendor/)
+	@go test -race ./...
 
 servedocs:
 	@docker run --rm -it -p 8000:8000 -v `pwd`:/docs squidfunk/mkdocs-material:$(MKDOCS_MATERIAL_VERSION)

--- a/internal/test/integration/Dockerfile
+++ b/internal/test/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9
 LABEL maintainer="matt@mattbostock.com"
 
 WORKDIR /go/src/github.com/mattbostock/athensdb


### PR DESCRIPTION
1.9 is the latest Go runtime.

Benefits from this release include:

- potentially faster compile times:
  https://golang.org/doc/go1.9#parallel-compile

- `runtime.ReadMemStats()` now takes less than 100µs, which will keep
  stop-the-world pauses to a minimum when scraping AthensDB's Prometheus
  metrics: https://golang.org/doc/go1.9#gc

- it's no longer necessary to filter out the `vendor/` directory when
  running `go test`: https://golang.org/doc/go1.9#vendor-dotdotdot

There are no anticipated downsides, aside from the potential for yet
undiscovered bugs in this version.

Release notes:
https://golang.org/doc/go1.9