### PR TITLE
Set retention to ~290 years

### DIFF
--- a/cmd/athensdb/main.go
+++ b/cmd/athensdb/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -110,7 +111,7 @@ func main() {
 		AppendableBlocks: 2,
 		MinBlockDuration: 2 * time.Hour,
 		MaxBlockDuration: 36 * time.Hour,
-		Retention:        15 * 24 * time.Hour,
+		Retention:        time.Duration(math.MaxInt64), // approximately 290 years
 	})
 	if err != nil {
 		log.Fatalf("Opening storage failed: %s", err)


### PR DESCRIPTION
Set the retention for time-series data as high as the `time.Duration`
type will allow, which is equivalent to approximately 290 years in
nanoseconds.

As a durable time-series database, AthensDB should try to retain data
for as long as possible.