### PR TITLE
Cluster: Split tests into subtests

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -35,7 +35,10 @@ func TestHashringDistribution(t *testing.T) {
 	for _, numTestNodes := range testClusterSizes {
 		for _, replFactor := range testReplicationFactors {
 			c.replicationFactor = replFactor
-			testSampleDistribution(t, numTestNodes, samples)
+			t.Run(fmt.Sprintf("%d replicas across %d nodes", replFactor, numTestNodes),
+				func(t *testing.T) {
+					testSampleDistribution(t, numTestNodes, samples)
+				})
 		}
 	}
 }


### PR DESCRIPTION
Use subtests to improve the structure of the cluster tests. This helps
to divide the output between test runs.

https://blog.golang.org/subtests

The tail of the verbose output from `go test` looks like this:

    --- PASS: TestHashringDistribution (6.98s)
        --- PASS: TestHashringDistribution/1_replicas_across_1_nodes (0.12s)
        --- PASS: TestHashringDistribution/3_replicas_across_1_nodes (0.26s)
        --- PASS: TestHashringDistribution/19_replicas_across_1_nodes (1.30s)
        --- PASS: TestHashringDistribution/1_replicas_across_3_nodes (0.13s)
        --- PASS: TestHashringDistribution/3_replicas_across_3_nodes (0.32s)
        --- PASS: TestHashringDistribution/19_replicas_across_3_nodes (1.41s)
        --- PASS: TestHashringDistribution/1_replicas_across_19_nodes (0.20s)
        --- PASS: TestHashringDistribution/3_replicas_across_19_nodes (0.40s)
        --- PASS: TestHashringDistribution/19_replicas_across_19_nodes (2.84s)
    PASS