### PR TITLE
Prefer prompb Marshal/Unmarshall functions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -321,6 +321,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a816b9d938ce95e5e305b1ffa39ffc6c93aba34f0538133812e80474cac6e371"
+  inputs-digest = "d33c758011d12eb56c04508faafba2ef5bc5fc930dd7beb12bb8759af7271a94"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/internal/test/testutil/testutil.go
+++ b/internal/test/testutil/testutil.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	promAPI "github.com/prometheus/client_golang/api"
 	promAPIv1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -107,7 +106,7 @@ func QueryAPI(baseURL, query string, ts time.Time) (model.Value, error) {
 }
 
 func PostWriteRequest(baseURL string, req *prompb.WriteRequest) (*http.Response, error) {
-	data, err := proto.Marshal(req)
+	data, err := req.Marshal()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/write/write.go
+++ b/internal/write/write.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/mattbostock/athensdb/internal/cluster"
 	"github.com/prometheus/prometheus/pkg/labels"
@@ -55,7 +54,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req = prompb.WriteRequest{Timeseries: make([]*prompb.TimeSeries, 0, numPreallocTimeseries)}
-	if err := proto.Unmarshal(reqBuf, &req); err != nil {
+	if err := req.Unmarshal(reqBuf); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -183,7 +182,7 @@ func remoteWrite(sampleMap sampleNodeMap) error {
 				req.Timeseries = append(req.Timeseries, ts)
 			}
 
-			data, err := proto.Marshal(req)
+			data, err := req.Marshal()
 			if err != nil {
 				wgErrChan <- err
 				return


### PR DESCRIPTION
Use the Marshall/Unmarshall methods available on the Protobuf data
structures that are generated by the gogo protobuf library:

https://github.com/gogo/protobuf

This library is supposed to be faster to marshal and unmarshal Protobufs
by avoiding reflection. From empirical testing, there is a small
improvement. The `MarshalTo()` method should also come in useful if I
start using `sync.Pool` to reuse objects and reduce memory allocations.

This change removes one direct dependency on the
`github.com/golang/protobuf/proto` package.