### PR TITLE
Optimise internal writes

### DIFF
--- a/internal/write/write.go
+++ b/internal/write/write.go
@@ -3,6 +3,7 @@ package write
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -56,6 +57,13 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	var req = prompb.WriteRequest{Timeseries: make([]*prompb.TimeSeries, 0, numPreallocTimeseries)}
 	if err := req.Unmarshal(reqBuf); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if len(req.Timeseries) == 0 {
+		err := errors.New("received empty request containing zero timeseries")
+		log.Warningln(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
Whenever a node forwards data to another node, it appends the
`HttpHeaderInternalWrite` HTTP header so that the receiving node knows
not to try to forward the data on (again).

This is a very common case: all data, assuming a replication factor
greater than 1, will traverse this path so make it as fast as
possible and return as soon as data is written.

Previously, internal writes occurred after determining which nodes
should store replicas of the data, which is expensive in terms of CPU.
Since internal writes are not replicated to other nodes, internal writes
should happen before then and return early.

The impact of this change is that nodes will blindly ingest any data
sent to them as an internal write; which I think for now is okay. I can
review this again when determining how to handle node failure in #33.

* * *

Also, delete the local node's data from `samplesToNodes` once the data is
written locally; otherwise the data will be sent as a HTTP request again
to be written a second time, which is unnecessary.