### PR TITLE
Output logs as JSON

### DIFF
--- a/cmd/athensdb/main.go
+++ b/cmd/athensdb/main.go
@@ -110,6 +110,7 @@ func main() {
 		kingpin.Fatalf("could not parse log level %q", *level)
 	}
 	log.SetLevel(lvl)
+	log.SetFormatter(&log.JSONFormatter{})
 
 	// FIXME: Set logger
 	localStorage, err := tsdb.Open("data", nil, prometheus.DefaultRegisterer, &tsdb.Options{


### PR DESCRIPTION
Output logs as JSON by default, so that log entries can be parsed in a
structured way.

I'd like to keep the colour human-readable that Logrus provides when a
TTY is in use, however for now the priority is to have JSON log output.
I may look at adding back more human-readable output in the near future.

I considered adding a configuration option for this, but I think the
JSON output is quite readable and I'd like to avoid adding configuration
options unless absolutely necessary.