### PR TITLE
Avoid package-level state

### DIFF
--- a/internal/cluster/memberlist.go
+++ b/internal/cluster/memberlist.go
@@ -1,0 +1,23 @@
+package cluster
+
+import "github.com/hashicorp/memberlist"
+
+type membership struct{ l *memberlist.Memberlist }
+
+func (m *membership) Nodes() Nodes {
+	nodes := make(Nodes, 0, len(m.l.Members()))
+	for _, n := range m.l.Members() {
+		nodes = append(nodes, &Node{n})
+	}
+	return nodes
+
+}
+
+func (m *membership) LocalNode() *Node {
+	return &Node{m.l.LocalNode()}
+}
+
+type Membership interface {
+	LocalNode() *Node
+	Nodes() Nodes
+}

--- a/internal/hashring/hashring.go
+++ b/internal/hashring/hashring.go
@@ -1,0 +1,16 @@
+package hashring
+
+import "github.com/golang/groupcache/consistenthash"
+
+func New(replicationFactor, vnodes int) *hashRing {
+	return &hashRing{consistenthash.New(replicationFactor*vnodes, nil)}
+}
+
+type hashRing struct {
+	*consistenthash.Map
+}
+
+type HashRing interface {
+	Add(...string)
+	Get(string) string
+}


### PR DESCRIPTION
Avoid package-level state in the `cluster` and `write` packages to make
testing easier and avoid side-effects when mutating package-level state.

I added interfaces to the `cluster` and (new) `hashring` packages, which
allows those packages to return an unexported struct from the `New()`
function while still allowing other packages to reference methods on
those structs via the interface.

This change means that the cluster distribution change is now able to
more closely emulate a real cluster without duplicating how the hash
ring is defined. Some of the tests have been tidied up accordingly to
use maps instead of slices where it made the code more readable.

Additionally, this change made it possible to rename `GetNodes()` to the
more idiomatic `Nodes()`.

Finally, `FilterBySeries()` has been renamed to `NodesByPartitionKey()`
and is a method on the `Cluster` interface rather than the `Nodes()`
type; this name seems more self-explanatory.