### PR TITLE
Include metric in partition key

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -100,12 +100,12 @@ func (c *cluster) NodesByPartitionKey(pKey uint64) Nodes {
 	return retNodes
 }
 
-func PartitionKey(salt []byte, end time.Time) uint64 {
+func PartitionKey(salt []byte, end time.Time, metricHash uint64) uint64 {
 	// FIXME filter quantile and le when hashing for data locality?
 	buf := make([]byte, 0, len(salt)+len(primaryKeyDateFormat))
 	buf = append(buf, salt...)
 	buf = append(buf, end.Format(primaryKeyDateFormat)...)
-	return xxhash.Sum64(buf)
+	return xxhash.Sum64(buf) + metricHash
 }
 
 func (c *cluster) ReplicationFactor() int {

--- a/internal/cluster/distribution_test.go
+++ b/internal/cluster/distribution_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cespare/xxhash"
 	"github.com/hashicorp/memberlist"
 	"github.com/mattbostock/athensdb/internal/hashring"
 	"github.com/mattbostock/athensdb/internal/test/testutil"
@@ -30,7 +31,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	samples = testutil.GenerateDataSamples(numSamples, 1, 24*time.Hour)
+	samples = testutil.GenerateDataSamples(numSamples, 1, time.Second)
 	os.Exit(m.Run())
 }
 
@@ -75,7 +76,7 @@ func testSampleDistribution(t *testing.T, clstr Cluster, samples model.Samples) 
 	var replicationSpread stats.Float64Data
 	for _, s := range samples {
 		spread := make(map[string]bool)
-		pKey := PartitionKey([]byte{}, s.Timestamp.Time())
+		pKey := PartitionKey([]byte{}, s.Timestamp.Time(), xxhash.Sum64String(s.Metric.String()))
 		for _, n := range clstr.NodesByPartitionKey(pKey) {
 			buckets[n.Name()] = append(buckets[n.Name()], s)
 			spread[n.Name()] = true

--- a/internal/write/write.go
+++ b/internal/write/write.go
@@ -133,7 +133,7 @@ func (wr *writer) Handler(w http.ResponseWriter, r *http.Request) {
 		for _, s := range ts.Samples {
 			timestamp := time.Unix(s.Timestamp/1000, (s.Timestamp-s.Timestamp/1000)*1e6)
 			// FIXME: Avoid panic if the cluster is not yet initialised
-			pKey := cluster.PartitionKey(pSalt, timestamp)
+			pKey := cluster.PartitionKey(pSalt, timestamp, mHash)
 			for _, n := range wr.clstr.NodesByPartitionKey(pKey) {
 				if _, ok := seriesToNodes[*n][mHash]; !ok {
 					// FIXME handle change in cluster size


### PR DESCRIPTION
Include all label names and label values in the partition key. Since the
metric name is a label with the magic name `__name__`, the metric name
also forms part of the partition key.

This change will ensure that data is distributed more evenly across the
cluster. Specifically, it will avoid n nodes in the cluster receiving
all write traffic for a 24-hour period, where n is the replication
factor.

The partition key could now be represented as:

    <salt>:<bucket_end_time_as_YYYYMMDD>:<metric_name>:[<label_name>,<label_name>...]

This change makes it more difficult to reason about which nodes should
contain what data, but I think it's a necessary change to allow
horizontal scaling to all but the smallest of cluster sizes. With the
current schema, you might have a 19-node cluster but only 3 nodes will
ingest data for a given day. With this change, all 19 nodes will be
eligible to ingest data.

Another potential downside is that query aggregations across labels with
for the same metric name may now need to aggregate across multiple
nodes, however there may be a performance benefit from distributing the
query more widely. This could be optimised to some extent in future by
giving special treatment to labels that have special significant in
Prometheus such as `le` (for histograms), `job`, `quantile` (for
percentile summaries) and `instance`.

For more discussion on partition keys, see:
https://github.com/mattbostock/athensdb/issues/12

The partition schema used here is schema B in issue #12.

The time step when generated data samples in `distribution_test.go` is
reduced as it is no longer necessary to spread samples across days to
test how well distributed samples are across the cluster (the previous
partition schema dictated as much).