### PR TITLE
Add -h short flag for help  and output usage on error

### DIFF
--- a/cmd/athensdb/main.go
+++ b/cmd/athensdb/main.go
@@ -104,19 +104,19 @@ func main() {
 		DefaultEnvars().
 		Parse(os.Args[1:])
 	if err != nil {
-		logFlagFatal(err)
+		kingpin.FatalUsage(err.Error())
 	}
 
 	if config.httpAdvertiseAddr.IP == nil || config.httpAdvertiseAddr.IP.IsUnspecified() {
-		logFlagFatal("must specify host or IP for --http-advertise-addr")
+		kingpin.FatalUsage("must specify host or IP for --http-advertise-addr")
 	}
 	if config.gossipAdvertiseAddr.IP == nil || config.gossipAdvertiseAddr.IP.IsUnspecified() {
-		logFlagFatal("must specify host or IP for --gossip-advertise-addr")
+		kingpin.FatalUsage("must specify host or IP for --gossip-advertise-addr")
 	}
 
 	lvl, err := log.ParseLevel(*level)
 	if err != nil {
-		kingpin.Fatalf("could not parse log level %q", *level)
+		kingpin.FatalUsage("could not parse log level %q", *level)
 	}
 	log.SetLevel(lvl)
 	log.SetFormatter(&log.JSONFormatter{})
@@ -199,8 +199,4 @@ func main() {
 	log.Infof("Advertising to cluster as %s for peer gossip; %s for HTTP", config.gossipAdvertiseAddr, config.httpAdvertiseAddr)
 	log.Infof("%d nodes in cluster: %s", len(clstr.Nodes()), clstr.Nodes())
 	log.Fatal(http.ListenAndServe(config.httpBindAddr.String(), router))
-}
-
-func logFlagFatal(v ...interface{}) {
-	log.Fatalf("%s: error: %s", os.Args[0], fmt.Sprint(v...))
 }


### PR DESCRIPTION
A `-h` short flag to see help is a common and convenient idiom.

* * *

Call `kingpin.FatalUsage()` on an error when processing flags, which
should give the user helpful information on how to fix their flags.

Removes the `logFlagFatal()` function, which means that flag errors are
no longer output as a structured logs, but I think that's okay - flag
errors should be as user-friendly as possible and having the usage
information is more useful than outputting errors as structured logs.

Example output:

    matt➜github.com/mattbostock/athensdb(104_usage✗)» athensdb --log-level=foo
    athensdb: error: enum value must be one of debug,info,warn,panic,fatal, got 'foo'
    usage: athensdb [<flags>]

    Flags:
      -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
          --data-directory="./data"  path to the directory to store data
          --http-advertise-addr=localhost:9080
                                    host:port to advertise to other nodes for HTTP
          --http-bind-addr=localhost:9080
                                    host:port to bind to for HTTP
          --gossip-advertise-addr=localhost:7946
                                    host:port to advertise to other nodes for cluster communication
          --gossip-bind-addr=localhost:7946
                                    host:port to bind to for cluster communication
          --peers=PEERS ...          List of peers to connect to
          --log-level=info           Log level
          --version                  Show application version.

    matt➜github.com/mattbostock/athensdb(104_usage✗)»

* * *

Closes #104.