### PR TITLE
Remove partition key salt

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -100,12 +100,9 @@ func (c *cluster) NodesByPartitionKey(pKey uint64) Nodes {
 	return retNodes
 }
 
-func PartitionKey(salt []byte, end time.Time, metricHash uint64) uint64 {
+func PartitionKey(end time.Time, metricHash uint64) uint64 {
 	// FIXME filter quantile and le when hashing for data locality?
-	buf := make([]byte, 0, len(salt)+len(primaryKeyDateFormat))
-	buf = append(buf, salt...)
-	buf = append(buf, end.Format(primaryKeyDateFormat)...)
-	return xxhash.Sum64(buf) + metricHash
+	return xxhash.Sum64String(end.Format(primaryKeyDateFormat)) + metricHash
 }
 
 func (c *cluster) ReplicationFactor() int {

--- a/internal/cluster/distribution_test.go
+++ b/internal/cluster/distribution_test.go
@@ -77,7 +77,7 @@ func testSampleDistribution(t *testing.T, clstr Cluster, samples model.Samples) 
 	var replicationSpread stats.Float64Data
 	for _, s := range samples {
 		spread := make(map[string]bool)
-		pKey := PartitionKey([]byte{}, s.Timestamp.Time(), xxhash.Sum64String(s.Metric.String()))
+		pKey := PartitionKey(s.Timestamp.Time(), xxhash.Sum64String(s.Metric.String()))
 		for _, n := range clstr.NodesByPartitionKey(pKey) {
 			buckets[n.Name()] = append(buckets[n.Name()], s)
 			spread[n.Name()] = true


### PR DESCRIPTION
This feature was not fully implemented, so remove it for now. I'll add
it back at a later date, with tests.

Updates #45.