### PR TITLE
Remove unused groupcache package dependency

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,10 +23,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/golang/groupcache"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/golang/protobuf"
 
 [[constraint]]


### PR DESCRIPTION
As of f3b2177612aa3e, this package is no longer required.