### PR TITLE
 Simplify read fanout

### DIFF
--- a/internal/read/read.go
+++ b/internal/read/read.go
@@ -81,18 +81,13 @@ func (re *reader) HandlerFunc(w http.ResponseWriter, r *http.Request) {
 		var querier storage.Querier
 		if internal {
 			querier, err = re.localStore.Querier(r.Context(), query.StartTimestampMs, query.EndTimestampMs)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				re.log.Error(err)
-				return
-			}
 		} else {
 			querier, err = re.fanoutStore.Querier(r.Context(), query.StartTimestampMs, query.EndTimestampMs)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				re.log.Error(err)
-				return
-			}
+		}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			re.log.Error(err)
+			return
 		}
 		defer querier.Close()
 

--- a/internal/read/read.go
+++ b/internal/read/read.go
@@ -68,7 +68,7 @@ func (re *reader) HandlerFunc(w http.ResponseWriter, r *http.Request) {
 		Results: make([]*prompb.QueryResult, len(req.Queries)),
 	}
 
-	internal := len(r.Header.Get(HTTPHeaderInternalRead)) > 0
+	internal := r.Header.Get(HTTPHeaderInternalRead) != ""
 	for i, query := range req.Queries {
 		// FIXME paralellise queries
 		matchers, err := fromLabelMatchers(query.Matchers)


### PR DESCRIPTION
- Rename fanoutQuerier to remoteQuerier, which is more descriptive of
  its role

- Only pass a URL to remoteQuerier to improve encapsulation

- Rename Read() to remoteRead() and make it a method of remoteQuerier
  since most of its arguments are fields belonging to remoteQuerier
d4e2a2e

- Remove duplicated error handling